### PR TITLE
Support for fetching users' e-mail addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Current Features
 
 This tool can supplement an official Slack team export by adding the following to it:
 
+* Users' e-mail addresses
 * File Uploads
 
 Installation
@@ -21,6 +22,17 @@ Usage
 -----
 
 First, run a full export of your Slack team, and have the produced zip file handy.
+
+Due to `archive/zip` limitations, these actions cannot modify archive in place.
+It's preferable to fetch e-mails first to avoid copying large attachments around.
+
+### Add users' e-mails to your export.
+To fetch all users' e-mail addresses and add them to the archive,
+user this command:
+
+    ./slack-advanced-exporter --input-archive your-slack-team-export.zip --output-archive export-with-emails.zip fetch-emails --api-token xoxp-123...
+
+You'll need to obtain an API token [here](https://api.slack.com/docs/oauth-test-tokens).
 
 ### Add all the File Attachments to your export.
 

--- a/cmd_fetch_emails.go
+++ b/cmd_fetch_emails.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+)
+
+func fetchEmails(inputArchive string, outputArchive string, slackApiToken string) error {
+	// Check the parameters.
+	if len(inputArchive) == 0 {
+		fmt.Printf("fetch-emails command requires --input-archive to be specified.\n")
+		os.Exit(1)
+	}
+	if len(outputArchive) == 0 {
+		fmt.Printf("fetch-emails command requires --output-archive to be specified.\n")
+		os.Exit(1)
+	}
+	if slackApiToken == "" {
+		fmt.Printf("fetch-emails command requires --api-token to be specified.\n")
+		os.Exit(1)
+	}
+
+	// Open the input archive.
+	r, err := zip.OpenReader(inputArchive)
+	if err != nil {
+		fmt.Printf("Could not open input archive for reading: %s\n", inputArchive)
+		os.Exit(1)
+	}
+	defer r.Close()
+
+	// Open the output archive.
+	f, err := os.Create(outputArchive)
+	if err != nil {
+		fmt.Printf("Could not open the output archive for writing: %s\n\n%s", outputArchive, err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	// Create a zip writer on the output archive.
+	w := zip.NewWriter(f)
+
+	// Run through all the files in the input archive.
+	for _, file := range r.File {
+		// Open the file from the input archive.
+		inReader, err := file.Open()
+		if err != nil {
+			fmt.Printf("Failed to open file in input archive: %s\n\n%s", file.Name, err)
+			os.Exit(1)
+		}
+
+		// Copy, because CreateHeader modifies it.
+		header := file.FileHeader
+
+		outFile, err := w.CreateHeader(&header)
+		if err != nil {
+			fmt.Printf("Failed to create file in output archive: %s\n\n%s", file.Name, err)
+			os.Exit(1)
+		}
+
+		if file.Name == "users.json" {
+			err = processUsersJson(outFile, inReader, slackApiToken)
+			if err != nil {
+				fmt.Printf("Failed to fetch users' emails.\n\n%s", err)
+				os.Exit(1)
+			}
+		} else {
+			_, err = io.Copy(outFile, inReader)
+			if err != nil {
+				fmt.Printf("Failed to copy file to output archive: %s\n\n%s", file.Name, err)
+				os.Exit(1)
+			}
+		}
+	}
+
+	// Close the output zip writer.
+	err = w.Close()
+	if err != nil {
+		fmt.Printf("Failed to close the output archive.\n\n%s", err)
+	}
+
+	return nil
+}
+
+func processUsersJson(output io.Writer, input io.Reader, slackApiToken string) error {
+	// We want to preserve all existing fields in JSON.
+	// By using interface{} (instead of struct), we can avoid describing all
+	// the fields (new ones might be added by Slack devs in the future!) at the cost of
+	// slight inconvenience of type assertions and working with maps.
+	var data []map[string]interface{}
+	err := json.NewDecoder(input).Decode(&data)
+	if err != nil {
+		return err
+	}
+
+	emails, err := fetchUserEmails(slackApiToken)
+	if err != nil {
+		return err
+	}
+
+	if len(data) == 0 {
+		return errors.New("Failed to find any users in users.json. Looks like something went wrong.")
+	}
+
+	for _, user := range data {
+		// These 'ok's only check for type assertion success.
+		// Map access would return untyped nil,
+		// which is fine, as untyped nil would fail both these type assertions.
+		name, _ := user["name"].(string)
+
+		if userid, ok := user["id"].(string); ok {
+			if profile, ok := user["profile"].(map[string]interface{}); ok {
+				email := emails[userid]
+
+				profile["email"] = email
+				log.Printf("%q (%q) -> %q", name, userid, email)
+			} else {
+				log.Printf("User %q doesn't have 'profile' in JSON file (unexpected error!)", userid)
+			}
+		} else {
+			log.Print("Some user array entry doesn't have id, skipping")
+		}
+	}
+	enc := json.NewEncoder(output)
+	// The same indent level as export zip uses.
+	enc.SetIndent("", "    ")
+	return enc.Encode(&data)
+}
+
+func fetchUserEmails(token string) (map[string]string, error) {
+	resp, err := http.Get("https://slack.com/api/users.list?token=" + url.QueryEscape(token))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Slack API returned HTTP code %d", resp.StatusCode)
+	}
+
+	// Here SlackUser struct is used instead of interface{}.
+	// It has very few fields defined, but the decoder will simply
+	// ignore extra fields, and we only need a couple of them.
+	var data struct {
+		Ok      bool        `json:"ok"`
+		Members []SlackUser `json:"members"`
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&data)
+	if err != nil {
+		return nil, err
+	}
+
+	if !data.Ok {
+		return nil, errors.New("Unexpected lack of ok=true in Slack API response. Is access token correct?")
+	}
+
+	res := make(map[string]string)
+	for _, user := range data.Members {
+		if user.Id != "" && user.Profile.Email != "" {
+			res[user.Id] = user.Profile.Email
+		}
+	}
+
+	return res, nil
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 
 	var inputArchive string
 	var outputArchive string
+	var slackApiToken string
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
@@ -38,6 +39,21 @@ func main() {
 			Usage:   "Fetch all file attachments and add them to the output archive.",
 			Action: func(c *cli.Context) error {
 				return fetchAttachments(inputArchive, outputArchive)
+			},
+		},
+		{
+			Name:    "fetch-emails",
+			Aliases: nil,
+			Usage:   "Fetch users' e-mail addresses using Slack API and them to the output archive.",
+			Action: func(c *cli.Context) error {
+				return fetchEmails(inputArchive, outputArchive, slackApiToken)
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:        "api-token",
+					Usage:       "Slack API token. Can be obtained here: https://api.slack.com/docs/oauth-test-tokens",
+					Destination: &slackApiToken,
+				},
 			},
 		},
 	}

--- a/model.go
+++ b/model.go
@@ -15,3 +15,14 @@ type SlackPost struct {
 	Ts      string     `json:"ts"`
 	File    *SlackFile `json:"file"`
 }
+
+// As it appears in users.json and /api/users.list.
+// There're obviously many more fields, but we only need a couple of them.
+type SlackUser struct {
+	Id      string           `json:"id"`
+	Profile SlackUserProfile `json:"profile"`
+}
+
+type SlackUserProfile struct {
+	Email string `json:"email"`
+}


### PR DESCRIPTION
Since some time ago, Slack export zip no longer includes user
e-mail addresses. However, they're still accessible through Slack API.

This commit adds new subcommand that fetches users' e-mail addresses
and adds them into user.json file inside the export zip.

Fixes #4.

**HOWEVER**, for some unknown reasons importing such archive with e-mails causes every message to be duplicated. This might be a bug in Mattermost itself. I suggest to not merge this PR until it's investigated (that's what I'm doing right now).