### PR TITLE
Adds homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Installation
 Release binaries can be downloaded from release tags on Github
 [here](https://github.com/grundleborg/slack-advanced-exporter/releases).
 
+Homebrew users can do
+
+```bash
+brew tap grundleborg/slack-advanced-exporter
+brew install slack-advanced-exporter
+```
+
 Usage
 -----
 


### PR DESCRIPTION
Most macOS users appreciate Homebrew installations because they provide a simple way to install CLI apps from *source* (rather than from a scary binary), and it makes uninstalls and updates easier too.

However, Homebrew rejects install formulas that don't use Go vendoring and that don't have underlying apps with repos with at least 20 forks. 

The easiest way to support Homebrew installations for slack-advanced-exporter without those criteria is to fork [mkraft/homebrew-slack-advanced-exporter](https://github.com/mkraft/homebrew-slack-advanced-exporter) to github.com/grundleborg and then merge this pull request to update the docs.

I think that's the easiest I can make it.
