### PR TITLE
Fix files for the new Slack export format

### DIFF
--- a/model.go
+++ b/model.go
@@ -8,12 +8,13 @@ type SlackFile struct {
 }
 
 type SlackPost struct {
-	User    string     `json:"user"`
-	Type    string     `json:"type"`
-	Subtype string     `json:"subtype"`
-	Text    string     `json:"text"`
-	Ts      string     `json:"ts"`
-	File    *SlackFile `json:"file"`
+	User    string       `json:"user"`
+	Type    string       `json:"type"`
+	Subtype string       `json:"subtype"`
+	Text    string       `json:"text"`
+	Ts      string       `json:"ts"`
+	File    *SlackFile   `json:"file"`
+	Files   []*SlackFile `json:"files"`
 }
 
 // As it appears in users.json and /api/users.list.


### PR DESCRIPTION
This PR adds support for the `files` directive in exported Slack posts (fix for #9). The older `file` option is still supported.

Do note that Mattermost does not seem to parse `files` correctly yet, so a bulk import of files may still fail.

### Binary files
For easier reference, these are the compiled **binaries** of the code from the PR that fixes the issue:
[slack-advanced-exporter-linux64.tar.gz](https://github.com/grundleborg/slack-advanced-exporter/files/2379808/slack-advanced-exporter.tar.gz)  
[slack-advanced-exporter-win64.tar.gz](https://github.com/grundleborg/slack-advanced-exporter/files/2558921/slack-advanced-exporter-win64.tar.gz)