### PR TITLE
Support API tokens on file download.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ use this command:
 
     ./slack-advanced-exporter --input-archive your-slack-team-export.zip --output-archive export-with-attachments.zip fetch-attachments
 
+You may need an API token to access some attachments. You can add `--api-token xoxp-123...`
+to this command if so, in the same way as for `fetch-emails`.
+
 Problems
 --------
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,14 @@ func main() {
 			Aliases: []string{"a"},
 			Usage:   "Fetch all file attachments and add them to the output archive.",
 			Action: func(c *cli.Context) error {
-				return fetchAttachments(inputArchive, outputArchive)
+				return fetchAttachments(inputArchive, outputArchive, slackApiToken)
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:        "api-token",
+					Usage:       "Slack API token. Can be obtained here: https://api.slack.com/docs/oauth-test-tokens",
+					Destination: &slackApiToken,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
The files in my private channel cannot be retrieved without providing the API token on download. With the existing code, the "files" end up being HTML sign-in pages.

This PR provides the API token as a bearer token via the `Authorization` header. It works for me. It allows (optionally) providing the `--apiToken` parameter to `fetch-attachments`.