### PR TITLE
Moved token to Authorization header for fetch-emails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.DS_Store
+
+go.mod
+go.sum
+
 COOKIE
 TOKEN
 export/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+rm ./slack-advanced-exporter ./slack-advanced-exporter.darwin-amd64.tar.gz ./slack-advanced-exporter.linux-amd64.tar.gz ./slack-advanced-exporter.windows-amd64.zip
+
+echo "Building macOS"
+env GOOS=darwin GOARCH=amd64 go build .
+tar -czf slack-advanced-exporter.darwin-amd64.tar.gz slack-advanced-exporter
+rm ./slack-advanced-exporter
+
+echo "Building Linux"
+env GOOS=linux GOARCH=amd64 go build .
+tar -czf slack-advanced-exporter.linux-amd64.tar.gz slack-advanced-exporter
+rm ./slack-advanced-exporter
+
+echo "Building Windows"
+env GOOS=windows GOARCH=amd64 go build .
+zip -q slack-advanced-exporter.windows-amd64.zip slack-advanced-exporter.exe
+rm ./slack-advanced-exporter.exe
+
+sha256sum ./slack-advanced-exporter.*

--- a/cmd_fetch_emails.go
+++ b/cmd_fetch_emails.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 )
 
@@ -134,7 +133,15 @@ func processUsersJson(output io.Writer, input io.Reader, slackApiToken string) e
 }
 
 func fetchUserEmails(token string) (map[string]string, error) {
-	resp, err := http.Get("https://slack.com/api/users.list?token=" + url.QueryEscape(token))
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", "https://slack.com/api/users.list", nil)
+	if err != nil {
+		return nil, fmt.Errorf("Got error %s when building the request", err.Error())
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := client.Do(req)
+
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ func main() {
 
 	app.Name = "Slack Advanced Exporter"
 	app.Usage = "A tool to augment official Slack data exports with additional data that Slack does not include by default."
-	app.Version = "0.2.0"
+	app.Version = "0.3.1"
 
 	var inputArchive string
 	var outputArchive string


### PR DESCRIPTION
Slack moved the authentication token to HTTP headers

Signed-off-by: Paul Rothrock <paul@movetoiceland.com>