### PR TITLE
Fix description for fetch-emails command

### DIFF
--- a/cmd/fetch_emails.go
+++ b/cmd/fetch_emails.go
@@ -19,7 +19,7 @@ var (
 
 var fetchEmailsCmd = &cobra.Command{
 	Use:   "fetch-emails",
-	Short: "Fetch all file attachments and add them to the output archive",
+	Short: "Fetch email addresses and add them to the corresponding user profiles",
 	RunE:  fetchEmails,
 }
 


### PR DESCRIPTION
The current description is copy-pasted from the fetch-attachments command